### PR TITLE
[Mac/Win] Support for Android chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install eol-ft-runner --save-dev
 | Safari  | ✅Yes  | ⛔️N/A |
 | Edge  | ✅Yes | ✅Yes  |
 | Edge Headless | 🛠Not Yet  | 🛠Not Yet  |
-| Android Chrome  | ✅Yes | 🛠Not Yet  |
+| Android Chrome  | ✅Yes | ✅Yes  |
 | iOS Safari  | 🛠Not Yet  | ⛔️N/A |
 | Internet Explorer  | ⛔️N/A  | 🛠Not Yet  |
 | Opera  | ❌No  | ❌No  |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install eol-ft-runner --save-dev
 | Safari  | ✅Yes  | ⛔️N/A |
 | Edge  | ✅Yes | ✅Yes  |
 | Edge Headless | 🛠Not Yet  | 🛠Not Yet  |
-| Android Chrome  | 🛠Not Yet  | 🛠Not Yet  |
+| Android Chrome  | ✅Yes | 🛠Not Yet  |
 | iOS Safari  | 🛠Not Yet  | ⛔️N/A |
 | Internet Explorer  | ⛔️N/A  | 🛠Not Yet  |
 | Opera  | ❌No  | ❌No  |
@@ -60,7 +60,7 @@ npm run test -- --config config.json --browser chrome --tags @sanity --cores 2
 ```
 In your package.json, the npm script `test` should point to the ft-runner executable: `./node_modules/eol-ft-runner/bin/ft-runner`.
 
-`browser` can be 'chrome', 'firefox', 'safari', 'edge'.
+`browser` can be 'chrome', 'firefox', 'safari', 'edge', 'android'.
 
 `tags` are cucumber tags found on the top of a scenario inside a feature file. Tags are optional, and will execute all scenarios if not provided. To run multiple tags, use `--tags "@sanity @smoke @etc"`.
 
@@ -84,6 +84,7 @@ Create the `config.json` file anywhere in your project, and provide its relative
 #### Read more:
 - [Driver class methods](./docs/driver.md)
 - [Differentiating desktop browser and mobile browser tests](./docs/desktop_mobile.md)
+- [Running tests on Android chrome browser](./docs/android_setup.md)
 - [Debugging tests in VSCode](./docs/vscode_debug.md)
 
 #### Sample test project

--- a/docs/android_setup.md
+++ b/docs/android_setup.md
@@ -1,57 +1,47 @@
 ## TEST SETUP FOR ANDROID CHROME
-### Step-1 : Setup Android SDK & Emulator
-Install Android Studio & SDK:
-- Download Android Studio from Android Developers website: https://developer.android.com/
+**Step-1 : Setup Android SDK & Emulator**
+- Install Android SDK by downloading Android Studio from Android Developers website: https://developer.android.com/
 - Take note of your Android SDK path in Android Studio -> Preferences -> Appearance & Behavior -> System Settings -> Android SDK (check "Android SDK Location")
 - Launch AVD in Android Studio and proceed to create an Android emulator
-- During AVD setup, download the latest version of Android OS to use with your AVD; All SDK support libraries should be installed along with the OS
-- Once your AVD is successfully created, launch your AVD and make sure Chrome (correct version) is installed. If not, you can install the latest version of the Chrome APK by drag-and-drop on the emulator window. The latest version of Chrome can be found online.
+- During AVD setup, download the required version of Android OS to use with your AVD; All SDK support libraries should be installed along with the OS
+- Once your AVD is successfully created, launch your AVD and make sure Chrome (required version) is installed in the emulator. If not, you can install the required version of the Chrome .apk file by drag-and-drop on to the emulator window. All versions of Android Chrome can be found online in sites like APKMirror.
 
-### Step-2 : Setup Android environment variables:
-- All environment can be declared in your bash_profile. To output your `PATH` variable, you can send this command on the terminal
-``` shell
-echo $PATH
+**Step-2 : Setup Android environment variables:**
+- Make sure the following environment variables are set up in your machine:
+``` markdown
+JAVA_HOME=<path_to_java_home_dir>
+ANDROID_HOME=<path_to_android_sdk>
 ```
-- Assuming your bash profile is named `bash_profile`, you can enter the following in your terminal:
-``` shell
-vim ~/.bash_profile
+- Add ANDROID_HOME to your path, along with other sdk directories in the below order:
+``` markdown
+PATH=$PATH:$ANDROID_HOME:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
 ```
-- Change to INSERT mode, and add new environment variable `ANDROID_HOME`
-``` shell
-export JAVA_HOME=<path_to_java_home_dir>
-export ANDROID_HOME=<path_to_android_sdk>
-export PATH=$PATH:$ANDROID_HOME:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
-```
-Do not change the sequence, otherwise emulator will not be detected in your bash
-- Save & exit. Re-launch your terminal window to reload the bash profile
-- To validate, run the following command on terminal
-``` shell
-echo $JAVA_HOME
-echo $ANDROID_HOME
-echo $PATH
-```
-- Check the number of AVD installed using below command:
+Do not change the sequence, otherwise emulator will not be detected properly in your shell.
+- Re-launch your terminal/command window to reload the changes
+- Check the number of AVDs installed using below command:
 ``` shell
 emulator -list-avds
 ```
 
-### Step-3 : Install appium in your project
+**Step-3 : Install appium in your project** \
 Install appium in your project using below command:
 ``` shell
 npm install appium --save-dev
 ```
-#### Why is appium not installed along with eol-ft-runner?
-Simple -- too many security vulnerabilities. Plus, mobile browser is not everyone's cup of tea, so if you need it, we do have it. You just need to install the dev-dependencies separately.
+_Why is appium not packaged along with eol-ft-runner?_ \
+_Simple, too many security vulnerabilities. Plus, mobile browser is not everyone's cup of tea, so if you need it, we do support it. You just need to install appium separately._
 
 
-### Step-4 : Install chromedriver
+**Step-4 : Install chromedriver** \
 If not already installed in your local package, Install chromedriver in your project using below command:
 ``` shell
 npm install chromedriver --save-dev
 ```
+The version of chromedriver should match the version of chrome installed in the emulator.    
 
 
-## Run your test(s) on Android Chrome in Emulator:
+
+## RUN YOUR TEST(S) ON ANDROID CHROME IN EMULATOR:
 ``` shell
 npm run test -- --config=config.json --tags=<tags> --browser=android
 ```

--- a/docs/android_setup.md
+++ b/docs/android_setup.md
@@ -1,6 +1,6 @@
 ## TEST SETUP FOR ANDROID CHROME
 **Step-1 : Setup Android SDK & Emulator**
-- Install Android SDK by downloading Android Studio from Android Developers website: https://developer.android.com/
+- Install Android SDK by downloading Android Studio from Android Developers website: https://developer.android.com/studio
 - Take note of your Android SDK path in Android Studio -> Preferences -> Appearance & Behavior -> System Settings -> Android SDK (check "Android SDK Location")
 - Launch AVD in Android Studio and proceed to create an Android emulator
 - During AVD setup, download the required version of Android OS to use with your AVD; All SDK support libraries should be installed along with the OS

--- a/docs/android_setup.md
+++ b/docs/android_setup.md
@@ -1,0 +1,57 @@
+## TEST SETUP FOR ANDROID CHROME
+### Step-1 : Setup Android SDK & Emulator
+Install Android Studio & SDK:
+- Download Android Studio from Android Developers website: https://developer.android.com/
+- Take note of your Android SDK path in Android Studio -> Preferences -> Appearance & Behavior -> System Settings -> Android SDK (check "Android SDK Location")
+- Launch AVD in Android Studio and proceed to create an Android emulator
+- During AVD setup, download the latest version of Android OS to use with your AVD; All SDK support libraries should be installed along with the OS
+- Once your AVD is successfully created, launch your AVD and make sure Chrome (correct version) is installed. If not, you can install the latest version of the Chrome APK by drag-and-drop on the emulator window. The latest version of Chrome can be found online.
+
+### Step-2 : Setup Android environment variables:
+- All environment can be declared in your bash_profile. To output your `PATH` variable, you can send this command on the terminal
+``` shell
+echo $PATH
+```
+- Assuming your bash profile is named `bash_profile`, you can enter the following in your terminal:
+``` shell
+vim ~/.bash_profile
+```
+- Change to INSERT mode, and add new environment variable `ANDROID_HOME`
+``` shell
+export JAVA_HOME=<path_to_java_home_dir>
+export ANDROID_HOME=<path_to_android_sdk>
+export PATH=$PATH:$ANDROID_HOME:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
+```
+Do not change the sequence, otherwise emulator will not be detected in your bash
+- Save & exit. Re-launch your terminal window to reload the bash profile
+- To validate, run the following command on terminal
+``` shell
+echo $JAVA_HOME
+echo $ANDROID_HOME
+echo $PATH
+```
+- Check the number of AVD installed using below command:
+``` shell
+emulator -list-avds
+```
+
+### Step-3 : Install appium in your project
+Install appium in your project using below command:
+``` shell
+npm install appium --save-dev
+```
+#### Why is appium not installed along with eol-ft-runner?
+Simple -- too many security vulnerabilities. Plus, mobile browser is not everyone's cup of tea, so if you need it, we do have it. You just need to install the dev-dependencies separately.
+
+
+### Step-4 : Install chromedriver
+If not already installed in your local package, Install chromedriver in your project using below command:
+``` shell
+npm install chromedriver --save-dev
+```
+
+
+## Run your test(s) on Android Chrome in Emulator:
+``` shell
+npm run test -- --config=config.json --tags=<tags> --browser=android
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eol-ft-runner",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -761,6 +761,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U="
+    },
     "gherkin": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.0.0.tgz",
@@ -979,6 +984,15 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "kill-port": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.0.tgz",
+      "integrity": "sha512-gwHRBZ3OLBcupsOJZlIt2Xvf6QqFH3lfdpGnmonXJnJrqq819UXtItGEU1rCMXHK6sXFlxdpkw8ka56rtWw/eQ==",
+      "requires": {
+        "get-them-args": "^1.3.1",
+        "shell-exec": "^1.0.2"
       }
     },
     "klaw": {
@@ -1530,6 +1544,11 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
+    "shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg=="
+    },
     "sort-array": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.1.tgz",
@@ -1868,6 +1887,31 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "wait-port": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.9.tgz",
+      "integrity": "sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^3.0.2",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "walk-back": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eol-ft-runner",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "Application UI test runner that integration Selenium, Appium & CucumberJS for an all-round UI testing experince in Behaviour-driven development (BDD)",
   "main": "index.js",
   "scripts": {
@@ -30,9 +30,11 @@
     "cucumber-html-reporter": "^5.2.0",
     "cucumber-junit": "^1.7.1",
     "jsdoc-to-markdown": "^6.0.1",
+    "kill-port": "^1.6.0",
     "lodash": "^4.17.15",
     "moment": "^2.25.3",
     "selenium-webdriver": "^4.0.0-alpha.7",
+    "wait-port": "^0.2.9",
     "yargs": "^15.3.1"
   }
 }

--- a/utils/appium-config.js
+++ b/utils/appium-config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    "appium": {
+      "url": "http://localhost:4723/wd/hub",
+      "address": "0.0.0.0",
+      "port": 4723,
+      "logLevel": "warn",
+      "defaultCapabilities": {
+        "avdArgs": "-no-snapshot-save"
+      }
+    }
+  };

--- a/utils/appium-manager.js
+++ b/utils/appium-manager.js
@@ -1,5 +1,6 @@
 const { execSync, spawn } = require('child_process');
 const config = require('./appium-config');
+const path = require('path');
 const kill = require('kill-port');
 
 const appiumConfig = config.appium;
@@ -11,7 +12,8 @@ const startAppium = () => {
     .toString()
     .trim();
 
-  const output = spawn(`${npmBin}/appium`, [
+  const appiumExe = (process.platform === 'win32') ? path.normalize(`${npmBin}/appium.cmd`) : `${npmBin}/appium`;
+  const output = spawn(appiumExe, [
     '--address',
     appiumConfig.address,
     '--log-level',

--- a/utils/appium-manager.js
+++ b/utils/appium-manager.js
@@ -1,0 +1,57 @@
+const { execSync, spawn } = require('child_process');
+const config = require('./appium-config');
+const kill = require('kill-port');
+
+const appiumConfig = config.appium;
+
+const startAppium = () => {
+  kill(appiumConfig.port);
+
+  const npmBin = execSync('npm bin')
+    .toString()
+    .trim();
+
+  const output = spawn(`${npmBin}/appium`, [
+    '--address',
+    appiumConfig.address,
+    '--log-level',
+    appiumConfig.logLevel,
+    '--port',
+    appiumConfig.port,
+    '--default-capabilities',
+    JSON.stringify(appiumConfig.defaultCapabilities),
+    '--chromedriver-executable',
+    require('chromedriver').path
+  ]);
+
+  output.stdout.on('data', data => {
+    console.log(`stdout: ${data}`);
+  });
+
+  output.stderr.on('data', err => {
+    console.error(`stderr: ${err}`);
+  });
+
+  output.on('error', err => {
+    console.error(`Error: ${err}`);
+    process.exit(1);
+  });
+
+  output.on('exit', (code, signal) => {
+    console.log(`Appium exited with ${code} on ${signal}`);
+  });
+
+  return output;
+};
+
+const stopAppium = server => {
+  server.kill('SIGHUP');
+};
+
+// const server = startAppiumServer();
+// setTimeout(() => { server.kill('SIGHUP')}, 10000);
+
+module.exports = {
+  startAppium: startAppium,
+  stopAppium: stopAppium
+};

--- a/utils/appium-manager.js
+++ b/utils/appium-manager.js
@@ -47,7 +47,12 @@ const startAppium = () => {
 };
 
 const stopAppium = server => {
-  server.kill('SIGHUP');
+  if (process.platform === "win32") {
+    const processInfo = execSync(`netstat -ano | findstr "0.0.0.0:4723"`, { encoding: 'utf-8'} );
+    const processPID = processInfo.trim().match(/[0-9]{3,5}$/g);
+    execSync(`taskkill /F /PID ${processPID}`);
+  }
+  else server.kill('SIGHUP');
 };
 
 // const server = startAppiumServer();

--- a/utils/desired-capabilities.js
+++ b/utils/desired-capabilities.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   android: {
     platformName: 'Android',
-    platformVersion: '9',
+    platformVersion: '10',
     browserName: 'Chrome',
     platform: 'ANDROID',
     newCommandTimeout: 30,

--- a/utils/emulator-manager.js
+++ b/utils/emulator-manager.js
@@ -1,0 +1,25 @@
+const { execSync } = require('child_process');
+
+// Export function -- Exit open Android simulator
+const exitAndroidEmulator = () => {
+    if (process.platform === 'win32') return null;
+    execSync('adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done');
+}
+
+const getEmulatorName = () => {
+    const stdout = execSync('emulator -list-avds', {
+      encoding: 'utf-8'
+    });
+
+    if (stdout) {
+      const emulators = stdout.trim().split('\n');
+      return emulators[0];
+    } else {
+      throw new Error(`No emulators found. Please create an AVD in Android Studio application.`);
+    }
+}
+
+module.exports = {
+    exitAndroidEmulator,
+    getEmulatorName
+};

--- a/utils/emulator-manager.js
+++ b/utils/emulator-manager.js
@@ -1,9 +1,23 @@
-const { execSync } = require('child_process');
+const { execSync, exec } = require('child_process');
 
 // Export function -- Exit open Android simulator
 const exitAndroidEmulator = () => {
-    if (process.platform === 'win32') return null;
-    execSync('adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done');
+    if (process.platform === 'win32') {
+      quitEmulatorOnWindows();
+    } else {
+      execSync('adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done');
+    }
+}
+
+const quitEmulatorOnWindows= () => {
+  exec("adb devices | findstr emulator", (err, stdout, stderr) => {
+    if (stdout !== "") {
+      const emulatorName = stdout.split('\t')[0].trim();
+      execSync(`adb -s ${emulatorName} emu kill`);
+    }
+
+    if (stderr !== "") console.error('Error closing android emulator');
+  });
 }
 
 const getEmulatorName = () => {

--- a/utils/modify-options.js
+++ b/utils/modify-options.js
@@ -14,7 +14,7 @@ async function processWorldParams(browserName, headlessFlag) {
 }
 
 async function processCores(browserName, cores) {
-    return ((browserName === 'safari' || browserName === 'edge')) ? 1 : (cores || 2);
+    return ((browserName === 'safari' || browserName === 'edge' || browserName === 'android')) ? 1 : (cores || 2);
 }
 
 module.exports = {

--- a/utils/utility.js
+++ b/utils/utility.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const { generateReport } = require('../utils/generate-report');
+const { exitAndroidEmulator } = require('./emulator-manager');
 
 const browserImgSrc = {
   firefox: 'https://raw.githubusercontent.com/moneesh2011/browser-icons/master/icons/32/firefox-32.png',
@@ -40,6 +41,7 @@ const cleanup = (browsers, reportsPath) => {
   browsers.forEach(browser => {
     fs.unlinkSync(`${reportsPath}/cucumber-report-${browser}.json`);
   });
+  if (global.browsers.includes('android')) exitAndroidEmulator();
 };
 
 const waitForReport = (reportsDir) => {

--- a/utils/world.js
+++ b/utils/world.js
@@ -4,9 +4,13 @@ const firefox = require('selenium-webdriver/firefox');
 const safari = require('selenium-webdriver/safari');
 const edge = require('selenium-webdriver/edge');
 const { setWorldConstructor, setDefaultTimeout } = require('cucumber');
-var caps = require('./desired-capabilities');
-var { Driver } = require('./driver');
 const fs = require('fs');
+
+var caps = require('./desired-capabilities');
+const config = require('./appium-config');
+const { getEmulatorName } = require('./emulator-manager');
+var { Driver } = require('./driver');
+let desiredCapabilities = require('./desired-capabilities');
 
 function setWinDriverPath(runner, browser) {
   if (process.platform === 'win32') {
@@ -110,6 +114,16 @@ function CustomWorld({ attach, parameters }) {
         this.browser = edge.Driver.createSession(options, service);
       }
     }
+  } else if (parameters.browser === 'android') {
+    const emulatorName = getEmulatorName();
+    desiredCapabilities.avd = emulatorName;
+    desiredCapabilities.deviceName = emulatorName;
+
+    // for mobile browsers -- android chrome
+    this.browser = new wd.Builder().forBrowser('android')
+      .usingServer(config.appium.url)
+      .withCapabilities(desiredCapabilities)
+      .build();
   }
 
   this.driver = new Driver(this.browser);


### PR DESCRIPTION
**Run tests on Android Chrome browser using Emulator**
- Adds support for running tests on Android Chrome browser using the Emulator
- Includes new doc on how to setup Android SDK & Emulator in your environment
- Supported for both Windows & Mac (x64 arch); Version is backwards-compatible with v0.2.x; Linux support coming soon, but might take longer due to questionable SDK support.