### PR TITLE
Add support for ios safari web

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install eol-ft-runner --save-dev
 | Edge  | ✅Yes | ✅Yes  |
 | Edge Headless | 🛠Not Yet  | 🛠Not Yet  |
 | Android Chrome  | ✅Yes | ✅Yes  |
-| iOS Safari  | 🛠Not Yet  | ⛔️N/A |
+| iOS Safari  | ✅Yes  | ⛔️N/A |
 | Internet Explorer  | ⛔️N/A  | 🛠Not Yet  |
 | Opera  | ❌No  | ❌No  |
 | Brave  | ❌No  | ❌No  |
@@ -85,6 +85,7 @@ Create the `config.json` file anywhere in your project, and provide its relative
 - [Driver class methods](./docs/driver.md)
 - [Differentiating desktop browser and mobile browser tests](./docs/desktop_mobile.md)
 - [Running tests on Android chrome browser](./docs/android_setup.md)
+- [Running tests on iOS Safari browser](./docs/ios_setup.md)
 - [Debugging tests in VSCode](./docs/vscode_debug.md)
 
 #### Sample test project

--- a/cli/test-runner.js
+++ b/cli/test-runner.js
@@ -68,7 +68,7 @@ async function execCommands(commands) {
         const done = _.after(global.browsers.length, () => {
             console.log('********** COMPLETED **********'.rainbow);
             mergeReports(global.browsers, global.reportsPath);
-            if (global.browsers.includes('android')) stopAppium(appiumServer);
+            if (global.browsers.includes('android') || global.browsers.includes('ios')) stopAppium(appiumServer);
         });
 
         commands.forEach(async (command, index) => {
@@ -92,9 +92,9 @@ async function runCucumberTests() {
     const commands = await getCucumberArgs();
     await checkDriverCompatibility(global.browsers);
     
-    if (global.browsers.includes('android')) {
+    if (global.browsers.includes('android') || global.browsers.includes('ios')) {
         console.log(`Mobile tests detected. Starting appium server...`.green);
-        appiumServer = startAppium();
+        appiumServer = startAppium(global.browsers);
         waitForPort({ host: appiumConfig.appium.address, port: appiumConfig.appium.port }).then(open => {
             if (open) {
                 execCommands(commands);

--- a/docs/ios_setup.md
+++ b/docs/ios_setup.md
@@ -1,0 +1,22 @@
+## TEST SETUP FOR IOS SAFARI
+Only supported on macOS. Linux, Windows and all other operating systems are unsupported.
+
+**Step-1 : Setup XCode**
+Download & Install XCode and iOS Simulator:
+- Install latest version of XCode from the Mac App Store
+- Launch XCode and go to Preferences: (Menu bar) XCode -> Preferences
+- In Preferences window, go to Components tab and download `iOS Simulator 13.5` (If not found, please ask your team for alternatives)
+- In terminal, enter the following to validate that XCode Command line tools are installed:
+``` shell
+xcrun simctl list devices
+```
+If successful, the output will return you all iOS Simulators installed on your mac.
+If unsuccessful, follow the output to install XCode command line tools
+- If you have more than one version of XCode on your machine, make sure you use the correct version using `xcode-select` command
+
+**Step-2 : Install Carthage**
+Using `brew`, install carthage in your environment:
+- Install using below command:
+``` shell
+brew install carthage
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eol-ft-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eol-ft-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Application UI test runner that integration Selenium, Appium & CucumberJS for an all-round UI testing experince in Behaviour-driven development (BDD)",
   "main": "index.js",
   "scripts": {

--- a/utils/appium-manager.js
+++ b/utils/appium-manager.js
@@ -5,7 +5,7 @@ const kill = require('kill-port');
 
 const appiumConfig = config.appium;
 
-const startAppium = () => {
+const startAppium = (browsers) => {
   kill(appiumConfig.port);
 
   const npmBin = execSync('npm bin')
@@ -13,7 +13,7 @@ const startAppium = () => {
     .trim();
 
   const appiumExe = (process.platform === 'win32') ? path.normalize(`${npmBin}/appium.cmd`) : `${npmBin}/appium`;
-  const output = spawn(appiumExe, [
+  let appiumArgs = [
     '--address',
     appiumConfig.address,
     '--log-level',
@@ -21,10 +21,18 @@ const startAppium = () => {
     '--port',
     appiumConfig.port,
     '--default-capabilities',
-    JSON.stringify(appiumConfig.defaultCapabilities),
-    '--chromedriver-executable',
-    require('chromedriver').path
-  ]);
+    JSON.stringify(appiumConfig.defaultCapabilities)
+  ];
+  
+  if (browsers.includes('android')) {
+    appiumArgs.push('--chromedriver-executable');
+    appiumArgs.push(require('chromedriver').path);
+  } 
+  if (browsers.includes('ios')) {
+    appiumArgs.push('--native-instruments-lib');
+  }
+
+  const output = spawn(appiumExe, appiumArgs);
 
   output.stdout.on('data', data => {
     console.log(`stdout: ${data}`);

--- a/utils/check-compatibility.js
+++ b/utils/check-compatibility.js
@@ -54,6 +54,13 @@ async function checkDriverCompatibility(browsers) {
         });
     }
 
+    if (_browsers.includes("ios")) {
+        console.log("No driver checks required for iOS. Skipping..");
+        _browsers = await _.remove(_browsers, (value) => {
+            return value !== "ios";
+        });
+    }
+
     if (_browsers.includes("chrome") || _browsers.includes("firefox") || _browsers.includes("android") || _browsers.includes("ie") || _browsers.includes("edge")) {
         for(i=0; i < _browsers.length; i++) {
             let browser = _browsers[i],

--- a/utils/desired-capabilities.js
+++ b/utils/desired-capabilities.js
@@ -27,12 +27,12 @@ module.exports = {
   },
   ios: {
     browserName: 'Safari',
-    platform: 'IOS',
     platformName: 'iOS',
-    platformVersion: '11.3',
-    deviceName: 'iPhone X',
+    platformVersion: '13.5',
+    deviceName: 'iPhone 11',
     automationName: 'XCUITest',
     startIWDP: true,
-    newCommandTimeout: 30
+    newCommandTimeout: 30,
+    safariAllowPopups: true
   }
 };

--- a/utils/emulator-manager.js
+++ b/utils/emulator-manager.js
@@ -20,6 +20,12 @@ const quitEmulatorOnWindows= () => {
   });
 }
 
+// Close Simulator App
+const closeSimulatorApp = () => {
+  const exitAppCmd = "quit app \"Simulator\"";
+  execSync(`osascript -e '${exitAppCmd}'`);
+};
+
 const getEmulatorName = () => {
     const stdout = execSync('emulator -list-avds', {
       encoding: 'utf-8'
@@ -35,5 +41,6 @@ const getEmulatorName = () => {
 
 module.exports = {
     exitAndroidEmulator,
-    getEmulatorName
+    getEmulatorName,
+    closeSimulatorApp
 };

--- a/utils/modify-options.js
+++ b/utils/modify-options.js
@@ -14,7 +14,7 @@ async function processWorldParams(browserName, headlessFlag) {
 }
 
 async function processCores(browserName, cores) {
-    return ((browserName === 'safari' || browserName === 'edge' || browserName === 'android')) ? 1 : (cores || 2);
+    return ((browserName === 'safari' || browserName === 'edge' || browserName === 'android' || browserName === 'ios')) ? 1 : (cores || 2);
 }
 
 module.exports = {

--- a/utils/utility.js
+++ b/utils/utility.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { generateReport } = require('../utils/generate-report');
-const { exitAndroidEmulator } = require('./emulator-manager');
+const { exitAndroidEmulator, closeSimulatorApp } = require('./emulator-manager');
 
 const browserImgSrc = {
   firefox: 'https://raw.githubusercontent.com/moneesh2011/browser-icons/master/icons/32/firefox-32.png',
@@ -42,6 +42,7 @@ const cleanup = (browsers, reportsPath) => {
     fs.unlinkSync(`${reportsPath}/cucumber-report-${browser}.json`);
   });
   if (global.browsers.includes('android')) exitAndroidEmulator();
+  else if (global.browsers.includes('ios')) closeSimulatorApp();
 };
 
 const waitForReport = (reportsDir) => {

--- a/utils/world.js
+++ b/utils/world.js
@@ -124,6 +124,12 @@ function CustomWorld({ attach, parameters }) {
       .usingServer(config.appium.url)
       .withCapabilities(desiredCapabilities)
       .build();
+  } else if (parameters.browser === 'ios') {
+    // for mobile browsers -- ios safari
+    this.browser = new wd.Builder()
+      .usingServer(config.appium.url)
+      .withCapabilities(desiredCapabilities)
+      .build();
   }
 
   this.driver = new Driver(this.browser);


### PR DESCRIPTION
**New features**
- Add support for iOS Safari web automation
- Currently iOS simulator is required with iOS 13.5; Support for more platforms coming soon
- Update README and add new documentation